### PR TITLE
Updates to Sample Setup

### DIFF
--- a/Sample/Cloud/README.md
+++ b/Sample/Cloud/README.md
@@ -2,9 +2,7 @@
 
 This directory contains tools to deploy and configure the cloud services that support the HealthKitOnFhir sample application. The [Create-IomtFhirCloudEnvironment.ps1](Scripts/Create-IomtFhirCloudEnvironment.ps1) script will deploy an [IoMT FHIR Connector for Azure](https://github.com/microsoft/iomt-fhir) and a FHIR server ([Azure API for FHIR](https://docs.microsoft.com/azure/healthcare-apis)) to your Azure account.
 
-
-
-# Prerequisites
+## Prerequisites
 
 **If you are running the PowerShell script in the Azure Cloud Shell, Installing the Az and AzureAd modules are not required.**
 
@@ -15,16 +13,28 @@ Install-Module Az
 Install-Module AzureAd
 ```
 
-**Mac:** Install the `Az` and `AzureAD.Standard.Preview` powershell modules:
+**Mac:** Powershell can be [installed using Homebrew].
+
+Register the package source to install the module:
+
+```PowerShell
+Register-PackageSource -Trusted -ProviderName 'PowerShellGet' -Name 'Posh Test Gallery' -Location https://www.poshtestgallery.com/api/v2/   
+```
+
+Install the `Az` and `AzureAD.Standard.Preview` powershell modules:
 
 ```PowerShell
 Install-Module Az
 Install-Module AzureAD.Standard.Preview -RequiredVersion 0.0.0.10
+
+import-Module AzureAD.Standard.Preview
 ```
 
-**Note:** The `AzureAD.Standard.Preview` powershell module is pre-release software go [here](https://www.poshtestgallery.com/packages/AzureAD.Standard.Preview/0.0.0.10) for more information.
+**Note:** The `AzureAD.Standard.Preview` powershell module is pre-release software. Go [here](https://www.poshtestgallery.com/packages/AzureAD.Standard.Preview/0.0.0.10) for more information.
 
-# Deployment
+[installed using Homebrew]:https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-core-on-macos?view=powershell-7.1#:~:text=There%20are%20several%20ways%20to%20install%20PowerShell%20on,is%20needed%20for%20PowerShell%20remoting%20and%20CIM%20operations
+
+## Deployment
 
 To deploy the sample scenario, first clone this git repo and find the deployment scripts folder:
 
@@ -33,10 +43,11 @@ git clone https://github.com/Microsoft/healthkit-on-fhir
 cd healthkit-on-fhir/Sample/Cloud/Scripts
 ```
 
-Log into your Azure subscription:
+Log into Azure and select the desired subscription:
 
 ```PowerShell
 Login-AzAccount
+Set-AzContext -Subscription <SUBSCRIPTION ID>
 ```
 
 Connect to Azure AD with:

--- a/Sample/Cloud/README.md
+++ b/Sample/Cloud/README.md
@@ -15,6 +15,8 @@ Install-Module AzureAd
 
 **Mac:** Powershell can be [installed using Homebrew].
 
+Launch the PowerShell shell environment (`pwsh` if installed via Homebrew).
+
 Register the package source to install the module:
 
 ```PowerShell

--- a/Sample/Cloud/Scripts/Create-IomtFhirCloudEnvironment.ps1
+++ b/Sample/Cloud/Scripts/Create-IomtFhirCloudEnvironment.ps1
@@ -98,13 +98,13 @@ $aadAuthority = "https://login.microsoftonline.com/${tenantDomain}"
 
 $fhirServerUrl = "https://${EnvironmentName}.azurehealthcareapis.com"
 
-$serviceClientId = (Get-AzKeyVaultSecret -VaultName "${EnvironmentName}-ts" -Name "${EnvironmentName}-service-client-id").SecretValueText
-$serviceClientSecret = (Get-AzKeyVaultSecret -VaultName "${EnvironmentName}-ts" -Name "${EnvironmentName}-service-client-secret").SecretValueText
+$serviceClientId = (Get-AzKeyVaultSecret -VaultName "${EnvironmentName}-ts" -Name "${EnvironmentName}-service-client-id" -AsPlainText)
+$serviceClientSecret = (Get-AzKeyVaultSecret -VaultName "${EnvironmentName}-ts" -Name "${EnvironmentName}-service-client-secret" -AsPlainText)
 $serviceClientObjectId = (Get-AzureADServicePrincipal -Filter "AppId eq '$serviceClientId'").ObjectId
-$publicClientId = (Get-AzKeyVaultSecret -VaultName "${EnvironmentName}-ts" -Name "${EnvironmentName}-public-client-id").SecretValueText
-$publicClientUserUpn  = (Get-AzKeyVaultSecret -VaultName "${EnvironmentName}-ts" -Name "${EnvironmentName}-admin-upn").SecretValueText
+$publicClientId = (Get-AzKeyVaultSecret -VaultName "${EnvironmentName}-ts" -Name "${EnvironmentName}-public-client-id" -AsPlainText)
+$publicClientUserUpn  = (Get-AzKeyVaultSecret -VaultName "${EnvironmentName}-ts" -Name "${EnvironmentName}-admin-upn" -AsPlainText)
 $publicClientUserOid = (Get-AzureADUser -Filter "UserPrincipalName eq '$publicClientUserUpn'").ObjectId
-$publicClientUserPassword  = (Get-AzKeyVaultSecret -VaultName "${EnvironmentName}-ts" -Name "${EnvironmentName}-admin-password").SecretValueText
+$publicClientUserPassword  = (Get-AzKeyVaultSecret -VaultName "${EnvironmentName}-ts" -Name "${EnvironmentName}-admin-password" -AsPlainText)
 
 $accessPolicies = @()
 $accessPolicies += @{ "objectId" = $currentObjectId.ToString() }


### PR DESCRIPTION
PR contains:
- More verbose instructions for running the setup scripts using PowerShell on a Mac.
- Updates to the environment creation script to remove deprecated secret query from Key Vault
  - https://docs.microsoft.com/en-us/powershell/module/az.keyvault/get-azkeyvaultsecret?view=azps-5.9.0#example-5--get-the-plain-text-value-of-the-current-version-of-a-specific-secret
  - Addresses issue #15  